### PR TITLE
Fixed: TypeError: can only join an iterable

### DIFF
--- a/aiohttp_cache/backends.py
+++ b/aiohttp_cache/backends.py
@@ -31,11 +31,11 @@ class BaseCache(object):
     async def set(self, key: str, value: dict, expires: int = 3000):
         raise NotImplementedError()
     
-    def make_key(self, request: aiohttp.web.Request) -> str:
+    async def make_key(self, request: aiohttp.web.Request) -> str:
         key = "{method}#{host}#{path}#{postdata}#{ctype}".format(method=request.method,
-                                                                 path=request.rel_url.query_string,
+                                                                 path=request.rel_url.path_qs,
                                                                  host=request.url.host,
-                                                                 postdata="".join(request.post()),
+                                                                 postdata="".join(await request.post()),
                                                                  ctype=request.content_type)
         
         return key

--- a/aiohttp_cache/middleware.py
+++ b/aiohttp_cache/middleware.py
@@ -13,7 +13,7 @@ async def cache_middleware(app, handler):
             
             cache_backend = app["cache"]
             
-            key = cache_backend.make_key(request)
+            key = await cache_backend.make_key(request)
 
             cached_response = await cache_backend.get(key)
             if cached_response:


### PR DESCRIPTION
Fixed issue from main repo https://github.com/cr0hn/aiohttp-cache/issues/3:
TypeError: can only join an iterable